### PR TITLE
Correct scale for Amount_of_charged_energy

### DIFF
--- a/00_VEDirect.pm
+++ b/00_VEDirect.pm
@@ -64,7 +64,7 @@ my %Text = ("V"=>{"ReadingName"=>"Main_or_channel_1_battery_voltage","Unit"=>"V"
             "H15"=>{"ReadingName"=>"Minimum_auxiliary_battery_voltage","Unit"=>"V","Scale"=>"0.001"},
             "H16"=>{"ReadingName"=>"Maximum_auxiliary_battery_voltage","Unit"=>"V","Scale"=>"0.001"},
             "H17"=>{"ReadingName"=>"Amount_of_discharged_energy","Unit"=>"kWh","Scale"=>"0.01"},
-            "H18"=>{"ReadingName"=>"Amount_of_charged_energy","Unit"=>"kWh","Scale"=>"100"},
+            "H18"=>{"ReadingName"=>"Amount_of_charged_energy","Unit"=>"kWh","Scale"=>"0.01"},
             "H19"=>{"ReadingName"=>"Yield_total_user_resettable_counter","Unit"=>"kWh","Scale"=>"0.01"},
             "H20"=>{"ReadingName"=>"Yield_today","Unit"=>"kWh","Scale"=>"0.01"},
             "H21"=>{"ReadingName"=>"Maximum_power_today","Unit"=>"W","Scale"=>"1"},


### PR DESCRIPTION
Amount_of_charged_energy was scaled with 100. Since Amount_of_discharged_energy is also kWh and scale is 0.01 the same should apply here.

Here the values from a SmartShunt 500 with the correction

Amount_of_charged_energy	
0.33 kWh	
2024-10-29 18:27:20

Amount_of_discharged_energy	
0.39 kWh	
2024-10-29 18:20:08